### PR TITLE
fix major.minor version string for high sierra

### DIFF
--- a/install.py
+++ b/install.py
@@ -22,7 +22,7 @@ if tuple(map(int, os.popen(command).read().strip().split('.'))) < (10, 0):
 
 command = 'defaults read %s PluginCompatibilityUUID' % mail_path
 compatibility_uuids = [ os.popen(command).read().strip() ]
-version = platform.mac_ver()[0]
+version = '.'.join(platform.mac_ver()[0].split('.')[:2])
 
 sys.argv[1:] = ['py2app'] + sys.argv[1:]
 sys.stdout = open(os.devnull, 'w')


### PR DESCRIPTION
Hi,

I just upgraded to High Sierra and the plugin unfortunately was disabled. It seems to be caused by the version string in `Supported%sPluginCompatibilityUUIDs`. The version I got is 10.13.1. Truncating this version string to 10.13 would work. This PR does the truncation.

<img width="418" alt="screen shot 2017-11-19 at 3 38 44 pm" src="https://user-images.githubusercontent.com/2121412/32995274-32232caa-cd40-11e7-954e-b924f2a98684.png">
 