### PR TITLE
Add "FixAttribution" user preference

### DIFF
--- a/MailFlow.py
+++ b/MailFlow.py
@@ -80,7 +80,7 @@ class ComposeViewController(Category('ComposeViewController')):
             view.changeQuoteLevel_(item)
 
             defaults = NSUserDefaults.standardUserDefaults()
-            defaults = defaults.dictionaryForKey_('MailWrap') or {}
+            defaults = defaults.dictionaryForKey_('MailFlow') or {}
             if defaults.get('FixAttribution', True):
                 attribution = view.selectedDOMRange().stringValue()
                 attribution = attribution.split(u',', 2)[-1].lstrip()

--- a/MailFlow.py
+++ b/MailFlow.py
@@ -1,4 +1,4 @@
-from AppKit import NSAlternateKeyMask, NSApplication, NSMenuItem
+from AppKit import NSAlternateKeyMask, NSApplication, NSMenuItem, NSUserDefaults
 import objc
 import re
 
@@ -79,14 +79,17 @@ class ComposeViewController(Category('ComposeViewController')):
             item.setTag_(-1)
             view.changeQuoteLevel_(item)
 
-            attribution = view.selectedDOMRange().stringValue()
-            attribution = attribution.split(u',', 2)[-1].lstrip()
-            if view.isAutomaticTextReplacementEnabled():
-                view.setAutomaticTextReplacementEnabled_(False)
-                view.insertText_(attribution)
-                view.setAutomaticTextReplacementEnabled_(True)
-            else:
-                view.insertText_(attribution)
+            defaults = NSUserDefaults.standardUserDefaults()
+            defaults = defaults.dictionaryForKey_('MailWrap') or {}
+            if defaults.get('FixAttribution', True):
+                attribution = view.selectedDOMRange().stringValue()
+                attribution = attribution.split(u',', 2)[-1].lstrip()
+                if view.isAutomaticTextReplacementEnabled():
+                    view.setAutomaticTextReplacementEnabled_(False)
+                    view.insertText_(attribution)
+                    view.setAutomaticTextReplacementEnabled_(True)
+                else:
+                    view.insertText_(attribution)
 
             signature = document.getElementById_('AppleMailSignature')
             if signature:


### PR DESCRIPTION
MailFlow is a really useful Apple Mail plugin.  Thank you!  Unfortunately,
in my case, the automatic fixing of the attribution to shorten it to just the
e-mail name doesn't work properly because the lead-in date has an extra
comma compared to the number skipped when fixing is done. I end up
with something like this:
```
at 9:01 PM, Example User <user@example.com> wrote:
```
The arachsys/mailwrap Apple Mail plugin on GitHub includes a user
preference to toggle on or off whether the plugin will fix the
attribution on replies. Mailflow lacks this user preference. This change
adds the same support for the `FixAttribution` user preference in
MailWrap to MailFlow.

The same sematics in MailWrap applies here. This information from the
MailWrap README also applies to this feature added to MailFlow:
```
  defaults write com.apple.mail MailWrap -dict-add FixAttribution -bool false
  defaults write com.apple.mail MailWrap -dict-add FixAttribution -bool true
    - configure MailWrap to strip the verbose date and time information
      from the attribution line when composing a reply. The default is on.
```