### PR TITLE
Add BottomPosting setting to control posting-style

### DIFF
--- a/MailFlow.py
+++ b/MailFlow.py
@@ -110,7 +110,8 @@ class ComposeViewController(Category('ComposeViewController')):
                     blockquote.parentNode().insertBefore__(
                         document.createElement_('BR'), blockquote)
 
-        view.insertParagraphSeparator_(None)
+        if self._bottomPosting:
+            view.insertParagraphSeparator_(None)
         view.undoManager().removeAllActions()
         self.setHasUserMadeChanges_(False)
         self.backEnd().setHasChanges_(False)
@@ -129,7 +130,13 @@ class ComposeViewController(Category('ComposeViewController')):
                 view.setSelectedDOMRange_affinity_(domrange, 0)
                 view.moveUp_(None)
             else:
-                view.moveToEndOfDocument_(None)
+                if self._bottomPosting:
+                    view.moveToEndOfDocument_(None)
+                else:
+                    view.moveToBeginningOfDocument_(None)
+                    view.insertParagraphSeparator_(None)
+                    view.insertParagraphSeparator_(None)
+                    view.moveToBeginningOfDocument_(None)
         return result
 
 
@@ -294,6 +301,7 @@ class MailFlow(Class('MVMailBundle')):
 
         defaults = NSUserDefaults.standardUserDefaults()
         defaults = defaults.dictionaryForKey_('MailFlow') or {}
+        ComposeViewController._bottomPosting = defaults.get('BottomPosting', True)
         ComposeViewController._fixAttribution = defaults.get('FixAttribution', True)
         MCMessageGenerator._flowWidth = int(defaults.get('FlowWidth', 76))
 

--- a/README
+++ b/README
@@ -200,6 +200,12 @@ Configuration
 MailFlow reads two preferences from the com.apple.mail domain. These can be
 set at the command line with the macOS defaults command:
 
+  defaults write com.apple.mail MailFlow -dict-add BottomPosting -bool false
+  defaults write com.apple.mail MailFlow -dict-add BottomPosting -bool true
+    - configure MailFlow to use bottom-posting (reply follows the quoted
+      original message). The default is on. Set to false to use top-posting
+      (reply precedes the quoted original message).
+
   defaults write com.apple.mail MailFlow -dict-add FixAttribution -bool false
   defaults write com.apple.mail MailFlow -dict-add FixAttribution -bool true
     - configure MailFlow to strip the verbose date and time information


### PR DESCRIPTION
I added the option `BottomPosting` to allow choosing the posting style. The default is on, which preserves the current MailFlow behavior. Setting it to false enables top-posting.